### PR TITLE
Upgrade Xdebug 2.6 to beta1.

### DIFF
--- a/soe/php7.2/Dockerfile
+++ b/soe/php7.2/Dockerfile
@@ -8,7 +8,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp
 
 # Install Xdebug alpha manually
 # @TODO: Replace with `php-xdebug` once oerdnj/deb.sury.org#751 is fixed.
-RUN pecl install xdebug-alpha \
+RUN pecl install xdebug-beta \
   && echo "zend_extension=xdebug.so" > /etc/php/7.2/mods-available/xdebug.ini \
   && phpenmod -s ALL xdebug
 


### PR DESCRIPTION
See https://xdebug.org/updates.php#x_2_6_0beta1 for release notes.

Ref #10