### PR TITLE
PHP 7.2: Upgrade xdebug to 2.6-stable

### DIFF
--- a/soe/php7.2/Dockerfile
+++ b/soe/php7.2/Dockerfile
@@ -3,13 +3,7 @@ FROM dockerdepot/php:7.2
 
 # Install all packages.
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp
-
-# Install Xdebug alpha manually
-# @TODO: Replace with `php-xdebug` once oerdnj/deb.sury.org#751 is fixed.
-RUN pecl install xdebug \
-  && echo "zend_extension=xdebug.so" > /etc/php/7.2/mods-available/xdebug.ini \
-  && phpenmod -s ALL xdebug
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp php-xdebug
 
 # Configure socat.
 ADD ./conf/socat/start.sh /root/socat-start.sh

--- a/soe/php7.2/Dockerfile
+++ b/soe/php7.2/Dockerfile
@@ -7,7 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp
 
 # Install Xdebug alpha manually
 # @TODO: Replace with `php-xdebug` once oerdnj/deb.sury.org#751 is fixed.
-RUN pecl install xdebug-beta \
+RUN pecl install xdebug \
   && echo "zend_extension=xdebug.so" > /etc/php/7.2/mods-available/xdebug.ini \
   && phpenmod -s ALL xdebug
 

--- a/spec/soe/php72_spec.rb
+++ b/spec/soe/php72_spec.rb
@@ -3,12 +3,7 @@ require 'spec_helper'
 describe 'PHP 7.2 SOE' do
   include_context 'soe' do
     let(:php_version) { '7.2' }
-    # @TODO: Replace with Constants::PHP70_SOE_PACKAGES once xdebug is
-    # installed via apt-get.
-    let(:soe_packages) { [
-      'socat',
-      'ssmtp'
-    ] }
+    let(:soe_packages) { Constants::PHP70_SOE_PACKAGES }
     let(:php_packages) { Constants::PHP72_PACKAGES }
     let(:apache_php_mod) { 'php7_module' }
     let(:ubuntu_version) { '16.04' }


### PR DESCRIPTION
Still no package, this uses the pecl package for now. Ref #10 